### PR TITLE
Implement simple Sinatra calendar with Telegram registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/db/*.sqlite3
+/tmp

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+gem "rake"
+
+source "https://rubygems.org"
+
+# gem "rails"
+gem 'sinatra'
+gem 'sinatra-contrib'
+gem 'sinatra-activerecord'
+gem 'sqlite3'
+gem 'telegram-bot-ruby'
+gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,131 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (8.0.2)
+      activesupport (= 8.0.2)
+    activerecord (8.0.2)
+      activemodel (= 8.0.2)
+      activesupport (= 8.0.2)
+      timeout (>= 0.4.0)
+    activesupport (8.0.2)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    bigdecimal (3.2.2)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.3)
+    daemons (1.4.1)
+    drb (2.2.3)
+    dry-core (1.1.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
+    dry-inflector (1.2.0)
+    dry-logic (1.6.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-struct (1.8.0)
+      dry-core (~> 1.1)
+      dry-types (~> 1.8, >= 1.8.2)
+      ice_nine (~> 0.11)
+      zeitwerk (~> 2.6)
+    dry-types (1.8.3)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
+    eventmachine (1.2.7)
+    faraday (2.13.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.1.1)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
+    json (2.12.2)
+    logger (1.7.0)
+    minitest (5.25.5)
+    multi_json (1.16.0)
+    multipart-post (2.4.1)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    net-http (0.6.0)
+      uri
+    rack (3.1.16)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rake (13.3.0)
+    ruby2_keywords (0.0.5)
+    securerandom (0.4.1)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    sinatra-activerecord (2.0.28)
+      activerecord (>= 4.1)
+      sinatra (>= 1.0)
+    sinatra-contrib (4.1.1)
+      multi_json (>= 0.0.2)
+      mustermann (~> 3.0)
+      rack-protection (= 4.1.1)
+      sinatra (= 4.1.1)
+      tilt (~> 2.0)
+    sqlite3 (2.7.2-x86_64-linux-gnu)
+    telegram-bot-ruby (2.4.0)
+      dry-struct (~> 1.6)
+      faraday (~> 2.0)
+      faraday-multipart (~> 1.0)
+      zeitwerk (~> 2.6)
+    thin (2.0.1)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      logger
+      rack (>= 1, < 4)
+    tilt (2.6.1)
+    timeout (0.4.3)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.0.3)
+    zeitwerk (2.7.3)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  rake
+  sinatra
+  sinatra-activerecord
+  sinatra-contrib
+  sqlite3
+  telegram-bot-ruby
+  thin
+
+BUNDLED WITH
+   2.4.19

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # aitests
+
+This example uses Sinatra with SQLite to manage a simple calendar.
+
+## Setup
+
+```bash
+bundle install
+bundle exec rake db:migrate
+bundle exec ruby db/seeds.rb
+```
+
+Run the application:
+
+```bash
+bundle exec ruby app.rb
+```
+
+Telegram bot script can be executed with:
+
+```bash
+TELEGRAM_TOKEN=your_token SERVER_URL=http://localhost:4567 ruby bot.rb
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require 'sinatra/activerecord/rake'
+require './app'

--- a/app.rb
+++ b/app.rb
@@ -1,0 +1,63 @@
+require 'sinatra'
+require 'sinatra/activerecord'
+require 'sinatra/json'
+require 'telegram/bot'
+
+set :database, {adapter: 'sqlite3', database: 'db/development.sqlite3'}
+
+enable :sessions
+
+class User < ActiveRecord::Base
+  validates :telegram_id, presence: true, uniqueness: true
+end
+
+class Slot < ActiveRecord::Base
+  validates :time, presence: true
+  has_and_belongs_to_many :users
+end
+
+helpers do
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+end
+
+get '/' do
+  redirect '/calendar'
+end
+
+get '/register' do
+  @user = current_user || User.new
+  erb :register
+end
+
+post '/register' do
+  @user = User.find_or_create_by(telegram_id: params[:telegram_id]) do |u|
+    u.name = params[:name]
+  end
+  session[:user_id] = @user.id
+  redirect '/calendar'
+end
+
+get '/calendar' do
+  @slots = Slot.order(:time).all
+  erb :calendar
+end
+
+post '/slots/:id/toggle' do
+  halt 401 unless current_user
+  slot = Slot.find(params[:id])
+  if slot.users.include?(current_user)
+    slot.users.delete(current_user)
+  else
+    slot.users << current_user
+  end
+  redirect '/calendar'
+end
+
+get '/api/slots' do
+  content_type :json
+  slots = Slot.includes(:users).order(:time)
+  data = slots.map { |s| { id: s.id, time: s.time, count: s.users.size, users: s.users.map(&:name) } }
+  json data
+end

--- a/bot.rb
+++ b/bot.rb
@@ -1,0 +1,17 @@
+require 'telegram/bot'
+require 'net/http'
+require 'uri'
+require 'json'
+
+TOKEN = ENV['TELEGRAM_TOKEN']
+SERVER_URL = ENV['SERVER_URL'] || 'http://localhost:4567'
+
+Telegram::Bot::Client.run(TOKEN) do |bot|
+  bot.listen do |message|
+    case message.text
+    when '/start'
+      uri = URI("#{SERVER_URL}/register")
+      bot.api.send_message(chat_id: message.chat.id, text: "Welcome, #{message.from.first_name}! Your Telegram ID is #{message.from.id}. Use this ID to register on the website.")
+    end
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/db/migrate/001_create_users.rb
+++ b/db/migrate/001_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :telegram_id, null: false
+      t.string :name
+      t.timestamps
+    end
+    add_index :users, :telegram_id, unique: true
+  end
+end

--- a/db/migrate/002_create_slots.rb
+++ b/db/migrate/002_create_slots.rb
@@ -1,0 +1,8 @@
+class CreateSlots < ActiveRecord::Migration[7.1]
+  def change
+    create_table :slots do |t|
+      t.datetime :time, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/003_create_slots_users.rb
+++ b/db/migrate/003_create_slots_users.rb
@@ -1,0 +1,8 @@
+class CreateSlotsUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :slots_users, id: false do |t|
+      t.belongs_to :slot
+      t.belongs_to :user
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,34 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 3) do
+  create_table "slots", force: :cascade do |t|
+    t.datetime "time", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "slots_users", id: false, force: :cascade do |t|
+    t.integer "slot_id"
+    t.integer "user_id"
+    t.index ["slot_id"], name: "index_slots_users_on_slot_id"
+    t.index ["user_id"], name: "index_slots_users_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "telegram_id", null: false
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["telegram_id"], name: "index_users_on_telegram_id", unique: true
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,9 @@
+require './app'
+
+start = Time.now.to_date.to_time + 8*60*60
+end_time = start + 10*60*60
+
+while start < end_time
+  Slot.find_or_create_by(time: start)
+  start += 30*60
+end

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,0 +1,13 @@
+function refresh() {
+  fetch('/api/slots').then(r => r.json()).then(data => {
+    data.forEach(slot => {
+      var row = document.querySelector('tr[data-id="' + slot.id + '"]');
+      if (!row) return;
+      row.querySelector('.count').textContent = slot.count;
+      row.querySelector('.users').textContent = slot.users.join(', ');
+      if (slot.count > 1) row.style.backgroundColor = '#ffeb3b';
+      else row.style.backgroundColor = '';
+    });
+  });
+}
+setInterval(refresh, 5000);

--- a/views/calendar.erb
+++ b/views/calendar.erb
@@ -1,0 +1,23 @@
+<h1>Calendar</h1>
+<p>Logged in as <%= current_user&.name || 'Guest' %></p>
+<% unless current_user %>
+  <a href="/register">Register</a>
+<% end %>
+<table id="calendar">
+  <% @slots.each do |slot| %>
+    <% users = slot.users %>
+    <tr data-id="<%= slot.id %>">
+      <td><%= slot.time.strftime('%H:%M') %></td>
+      <td class="count"><%= users.count %></td>
+      <td>
+        <% if current_user %>
+          <form action="/slots/<%= slot.id %>/toggle" method="post" style="display:inline;">
+            <button type="submit"<%= ' class="selected"' if users.include?(current_user) %>>Toggle</button>
+          </form>
+        <% end %>
+        <span class="users"><%= users.map(&:name).join(', ') %></span>
+      </td>
+    </tr>
+  <% end %>
+</table>
+<script src="/js/app.js"></script>

--- a/views/register.erb
+++ b/views/register.erb
@@ -1,0 +1,11 @@
+<h1>Register</h1>
+<form action="/register" method="post">
+  <label>Telegram ID:</label>
+  <input type="text" name="telegram_id" value="<%= @user.telegram_id %>" required>
+  <br>
+  <label>Name:</label>
+  <input type="text" name="name" value="<%= @user.name %>" required>
+  <br>
+  <input type="submit" value="Register">
+</form>
+<p>Start the Telegram bot and get your ID via /start.</p>


### PR DESCRIPTION
## Summary
- set up Sinatra project with ActiveRecord and SQLite
- add models, migrations, seeds and Rake tasks
- implement Telegram bot helper script
- build register and calendar pages with polling updates
- document setup steps

## Testing
- `bundle install`
- `bundle exec rake db:migrate`
- `bundle exec ruby db/seeds.rb`
- `ruby -c app.rb`


------
https://chatgpt.com/codex/tasks/task_e_6874d776e740832284a14fcd46fe9a42