### PR TITLE
Improve rule notes and add day view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/db/*.sqlite3
+/tmp

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+gem "rake"
+
+source "https://rubygems.org"
+
+# gem "rails"
+gem 'sinatra'
+gem 'sinatra-contrib'
+gem 'sinatra-activerecord'
+gem 'sqlite3'
+gem 'telegram-bot-ruby'
+gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,131 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (8.0.2)
+      activesupport (= 8.0.2)
+    activerecord (8.0.2)
+      activemodel (= 8.0.2)
+      activesupport (= 8.0.2)
+      timeout (>= 0.4.0)
+    activesupport (8.0.2)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    bigdecimal (3.2.2)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.3)
+    daemons (1.4.1)
+    drb (2.2.3)
+    dry-core (1.1.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
+    dry-inflector (1.2.0)
+    dry-logic (1.6.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-struct (1.8.0)
+      dry-core (~> 1.1)
+      dry-types (~> 1.8, >= 1.8.2)
+      ice_nine (~> 0.11)
+      zeitwerk (~> 2.6)
+    dry-types (1.8.3)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
+    eventmachine (1.2.7)
+    faraday (2.13.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.1.1)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
+    json (2.12.2)
+    logger (1.7.0)
+    minitest (5.25.5)
+    multi_json (1.16.0)
+    multipart-post (2.4.1)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    net-http (0.6.0)
+      uri
+    rack (3.1.16)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rake (13.3.0)
+    ruby2_keywords (0.0.5)
+    securerandom (0.4.1)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    sinatra-activerecord (2.0.28)
+      activerecord (>= 4.1)
+      sinatra (>= 1.0)
+    sinatra-contrib (4.1.1)
+      multi_json (>= 0.0.2)
+      mustermann (~> 3.0)
+      rack-protection (= 4.1.1)
+      sinatra (= 4.1.1)
+      tilt (~> 2.0)
+    sqlite3 (2.7.2-x86_64-linux-gnu)
+    telegram-bot-ruby (2.4.0)
+      dry-struct (~> 1.6)
+      faraday (~> 2.0)
+      faraday-multipart (~> 1.0)
+      zeitwerk (~> 2.6)
+    thin (2.0.1)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      logger
+      rack (>= 1, < 4)
+    tilt (2.6.1)
+    timeout (0.4.3)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.0.3)
+    zeitwerk (2.7.3)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  rake
+  sinatra
+  sinatra-activerecord
+  sinatra-contrib
+  sqlite3
+  telegram-bot-ruby
+  thin
+
+BUNDLED WITH
+   2.4.19

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # aitests
+
+This example uses Sinatra with SQLite to manage a simple calendar.
+
+## Setup
+
+```bash
+bundle install
+bundle exec rake db:migrate
+bundle exec ruby db/seeds.rb
+```
+
+Run the application:
+
+```bash
+bundle exec ruby app.rb
+```
+
+Telegram bot script can be executed with:
+
+```bash
+TELEGRAM_TOKEN=your_token SERVER_URL=http://localhost:4567 ruby bot.rb
+```
+
+The bot sends you a personalized link that automatically logs you in via `/auth`. Once logged in, a Vue.js powered calendar displays 30‑minute slots with a polished Bootstrap theme. Click a slot to join or leave that time. Use the number field to add extra participants (up to 10) so your name appears as `Your Name +N`. Hover over a slot to see participant names. Use the **Add Rule** button to select multiple slots and set a note for them, which highlights those cells in green. Cells darken as more users select the same slot and navigation links allow you to switch weeks.
+
+The `/api/slots` endpoint caches responses per week and clears the cache when slots change, reducing database load.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require 'sinatra/activerecord/rake'
+require './app'

--- a/app.rb
+++ b/app.rb
@@ -1,0 +1,129 @@
+require 'sinatra'
+require 'sinatra/activerecord'
+require 'sinatra/json'
+require 'telegram/bot'
+require 'date'
+
+set :database, {adapter: 'sqlite3', database: 'db/development.sqlite3'}
+
+enable :sessions
+
+# simple in-memory cache for slot data per week
+SLOTS_CACHE = {}
+
+class SlotUser < ActiveRecord::Base
+  self.table_name = 'slots_users'
+  belongs_to :slot
+  belongs_to :user
+end
+
+class User < ActiveRecord::Base
+  validates :telegram_id, presence: true, uniqueness: true
+  has_many :slot_users, class_name: 'SlotUser'
+  has_many :slots, through: :slot_users
+end
+
+class Slot < ActiveRecord::Base
+  validates :time, presence: true
+  has_many :slot_users, class_name: 'SlotUser'
+  has_many :users, through: :slot_users
+
+  def participant_count
+    slot_users.sum('1 + extra')
+  end
+end
+
+helpers do
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+end
+
+get '/' do
+  redirect '/calendar'
+end
+
+
+get '/auth' do
+  telegram_id = params[:telegram_id]
+  name = params[:name]
+  halt 400 unless telegram_id && name
+  user = User.find_or_create_by(telegram_id: telegram_id) do |u|
+    u.name = name
+  end
+  session[:user_id] = user.id
+  redirect '/calendar'
+end
+
+get '/register' do
+  @user = current_user || User.new(telegram_id: params[:telegram_id], name: params[:name])
+  erb :register
+end
+
+post '/register' do
+  @user = User.find_or_create_by(telegram_id: params[:telegram_id]) do |u|
+    u.name = params[:name]
+  end
+  session[:user_id] = @user.id
+  redirect '/calendar'
+end
+
+get '/calendar' do
+  date = params[:week] ? Date.parse(params[:week]) : Date.today
+  @start_week = date.beginning_of_week
+  @prev_week = @start_week - 7
+  @next_week = @start_week + 7
+  erb :calendar
+end
+
+post '/slots/:id/toggle' do
+  halt 401 unless current_user
+  payload = request.body.read
+  data = payload.empty? ? {} : JSON.parse(payload)
+  extra = data['extra'].to_i
+  slot = Slot.find(params[:id])
+  su = SlotUser.find_by(slot: slot, user: current_user)
+  if su
+    SlotUser.where(slot: slot, user: current_user).delete_all
+  else
+    SlotUser.create(slot: slot, user: current_user, extra: extra)
+  end
+  SLOTS_CACHE.clear
+  content_type :json
+  { success: true }.to_json
+end
+
+post '/slots/set_rule' do
+  halt 401 unless current_user
+  payload = request.body.read
+  data = payload.empty? ? {} : JSON.parse(payload)
+  ids = data['slot_ids']
+  note = data['note']
+  Slot.where(id: ids).update_all(note: note)
+  SLOTS_CACHE.clear
+  content_type :json
+  { success: true }.to_json
+end
+
+get '/api/slots' do
+  content_type :json
+  date = params[:week] ? Date.parse(params[:week]) : Date.today
+  start_week = date.beginning_of_week
+  key = start_week.to_s
+  if SLOTS_CACHE[key]
+    return SLOTS_CACHE[key]
+  end
+  slots = Slot.includes(slot_users: :user).where(time: start_week..(start_week + 7)).order(:time)
+  data = slots.map do |s|
+    {
+      id: s.id,
+      time: s.time,
+      count: s.participant_count,
+      users: s.slot_users.map { |su| su.extra.positive? ? "#{su.user.name} +#{su.extra}" : su.user.name },
+      selected: current_user ? s.slot_users.any? { |su| su.user_id == current_user.id } : false,
+      note: s.note
+    }
+  end.to_json
+  SLOTS_CACHE[key] = data
+  data
+end

--- a/bot.rb
+++ b/bot.rb
@@ -1,0 +1,17 @@
+require 'telegram/bot'
+require 'net/http'
+require 'uri'
+require 'json'
+
+TOKEN = ENV['TELEGRAM_TOKEN']
+SERVER_URL = ENV['SERVER_URL'] || 'http://localhost:4567'
+
+Telegram::Bot::Client.run(TOKEN) do |bot|
+  bot.listen do |message|
+    case message.text
+    when '/start'
+      link = "#{SERVER_URL}/auth?telegram_id=#{message.from.id}&name=#{URI.encode_www_form_component(message.from.first_name)}"
+      bot.api.send_message(chat_id: message.chat.id, text: "Welcome, #{message.from.first_name}! Open this link to access the calendar: #{link}")
+    end
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/db/migrate/001_create_users.rb
+++ b/db/migrate/001_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :telegram_id, null: false
+      t.string :name
+      t.timestamps
+    end
+    add_index :users, :telegram_id, unique: true
+  end
+end

--- a/db/migrate/002_create_slots.rb
+++ b/db/migrate/002_create_slots.rb
@@ -1,0 +1,8 @@
+class CreateSlots < ActiveRecord::Migration[7.1]
+  def change
+    create_table :slots do |t|
+      t.datetime :time, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/003_create_slots_users.rb
+++ b/db/migrate/003_create_slots_users.rb
@@ -1,0 +1,8 @@
+class CreateSlotsUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :slots_users, id: false do |t|
+      t.belongs_to :slot
+      t.belongs_to :user
+    end
+  end
+end

--- a/db/migrate/004_add_note_to_slots.rb
+++ b/db/migrate/004_add_note_to_slots.rb
@@ -1,0 +1,5 @@
+class AddNoteToSlots < ActiveRecord::Migration[7.1]
+  def change
+    add_column :slots, :note, :string
+  end
+end

--- a/db/migrate/005_add_extra_to_slots_users.rb
+++ b/db/migrate/005_add_extra_to_slots_users.rb
@@ -1,0 +1,5 @@
+class AddExtraToSlotsUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :slots_users, :extra, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,36 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 5) do
+  create_table "slots", force: :cascade do |t|
+    t.datetime "time", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "note"
+  end
+
+  create_table "slots_users", id: false, force: :cascade do |t|
+    t.integer "slot_id"
+    t.integer "user_id"
+    t.integer "extra", default: 0, null: false
+    t.index ["slot_id"], name: "index_slots_users_on_slot_id"
+    t.index ["user_id"], name: "index_slots_users_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "telegram_id", null: false
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["telegram_id"], name: "index_users_on_telegram_id", unique: true
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,12 @@
+require './app'
+
+start_date = Date.today.beginning_of_week
+(0..6).each do |d|
+  day = start_date + d
+  time = day.to_time + 15 * 60 * 60
+  end_time = day.to_time + 24 * 60 * 60
+  while time < end_time
+    Slot.find_or_create_by(time: time)
+    time += 30 * 60
+  end
+end

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,95 @@
+body {
+  background-color: #eef7fd;
+  overflow-y: hidden;
+}
+.nav {
+  margin-bottom: 1rem;
+}
+table.calendar {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+}
+table.calendar th,
+table.calendar td {
+  border: 1px solid #dee2e6;
+  text-align: center;
+  padding: 0.25rem;
+  height: calc((100vh - 230px)/18);
+  font-size: .8rem;
+}
+table.calendar th {
+  background-color: #cfe2ff;
+}
+table.calendar td.slot {
+  cursor: pointer;
+  position: relative;
+  transition: background-color 0.3s ease;
+}
+table.calendar td.slot .count {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1rem;
+  font-weight: bold;
+  color: #000;
+}
+table.calendar td.slot:hover {
+  filter: brightness(0.95);
+}
+table.calendar td.slot.rule-select {
+  outline: 2px dashed #198754;
+}
+table.calendar td.slot .note {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  font-size: 0.7rem;
+  color: #0f5132;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rule-bar {
+  position: absolute;
+  display: none;
+  z-index: 1000;
+  max-width: 220px;
+}
+
+table.days {
+  width: 100%;
+  table-layout: fixed;
+}
+table.days td.day {
+  cursor: pointer;
+  border: 1px solid #dee2e6;
+  background-color: #cfe2ff;
+  position: relative;
+  height: calc((100vh - 230px)/7);
+  text-align: center;
+  vertical-align: middle;
+  transition: background-color 0.3s ease;
+}
+table.days td.day .day-label {
+  font-weight: bold;
+}
+table.days td.day .count {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  font-size: 0.8rem;
+}
+table.days td.day.has-rule {
+  background-color: #d4edda;
+}
+table.calendar td.slot .avg {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  font-size: 0.7rem;
+  color: #000;
+}

--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -1,0 +1,188 @@
+const { createApp } = Vue;
+createApp({
+  data() {
+    return {
+      week: WEEK,
+      prevWeek: PREV_WEEK,
+      nextWeek: NEXT_WEEK,
+      slots: [],
+      ruleMode: false,
+      ruleText: '',
+      selectedForRule: [],
+      ruleBarPos: {top: 0, left: 0},
+      extra: 0,
+      dayView: null
+    };
+  },
+  computed: {
+    days() {
+      const start = new Date(this.week);
+      start.setHours(0,0,0,0);
+      return Array.from({length:7}, (_,i)=>new Date(start.getTime()+i*86400000));
+    },
+    times() {
+      const start = new Date(this.week);
+      start.setHours(15,0,0,0);
+      return Array.from({length:18}, (_,i)=>new Date(start.getTime()+i*1800000));
+    },
+    monthLabel() {
+      const d = new Date(this.week);
+      return d.toLocaleDateString(undefined,{month:'long', year:'numeric'});
+    },
+    ruleAverages() {
+      const groups = {};
+      this.slots.forEach(s=>{
+        if(s.note){
+          if(!groups[s.note]) groups[s.note]={sum:0,count:0};
+          groups[s.note].sum += s.count;
+          groups[s.note].count++;
+        }
+      });
+      const avgs={};
+      Object.keys(groups).forEach(n=>{
+        avgs[n]=Math.round(groups[n].sum/groups[n].count);
+      });
+      return avgs;
+    },
+    slotsByDay() {
+      const map={};
+      this.days.forEach((_,i)=>map[i]=[]);
+      this.slots.forEach(s=>{
+        const d=new Date(s.time);
+        const idx=Math.floor((d-this.getStartOfWeek())/86400000);
+        if(map[idx]) map[idx].push(s);
+      });
+      return map;
+    },
+    maxPerDay() {
+      return this.days.map((_,i)=>{
+        let max=0; let note=false;
+        (this.slotsByDay[i]||[]).forEach(s=>{
+          if(s.count>max) max=s.count;
+          if(s.note) note=true;
+        });
+        return {max, note};
+      });
+    },
+    selectedAvg() {
+      if(!this.selectedForRule.length) return 0;
+      let sum = 0;
+      this.selectedForRule.forEach(id => {
+        const s = this.slots.find(sl=>sl.id===id);
+        if(s) sum += s.count;
+      });
+      return Math.round(sum/this.selectedForRule.length);
+    }
+  },
+  mounted() {
+    this.loadSlots();
+    setInterval(this.loadSlots, 5000);
+  },
+  updated() {
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
+      bootstrap.Tooltip.getInstance(el)?.dispose();
+      new bootstrap.Tooltip(el, {trigger:'hover'});
+    });
+    const bar = document.getElementById('rule-bar');
+    if(bar) {
+      const style = this.ruleBarStyle();
+      Object.assign(bar.style, style);
+    }
+  },
+  methods: {
+    getStartOfWeek(){
+      const d=new Date(this.week); d.setHours(0,0,0,0); return d.getTime();
+    },
+    formatDay(d) {
+      return new Date(d).toLocaleDateString(undefined,{weekday:'short',day:'numeric'});
+    },
+    formatTime(t) {
+      return new Date(t).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', hour12:false});
+    },
+    findSlot(day,time) {
+      const dt = new Date(day.getFullYear(), day.getMonth(), day.getDate(), time.getHours(), time.getMinutes());
+      return this.slots.find(s => new Date(s.time).getTime() === dt.getTime());
+    },
+    findSlotByIndex(dayIndex,time){
+      const day=this.days[dayIndex];
+      return this.findSlot(day,time);
+    },
+    loadSlots() {
+      fetch(`/api/slots?week=${this.week}`)
+        .then(r=>r.json())
+        .then(data=>{ this.slots = data; });
+    },
+    onSlotClick(slot, event) {
+      if(!slot) return;
+      if(this.ruleMode) {
+        const idx = this.selectedForRule.indexOf(slot.id);
+        if(idx>=0) this.selectedForRule.splice(idx,1);
+        else this.selectedForRule.push(slot.id);
+        if(event) {
+          const rect = event.target.getBoundingClientRect();
+          this.ruleBarPos = {top: rect.bottom + window.scrollY + 4, left: rect.left + window.scrollX};
+        }
+      } else {
+        this.toggleSlot(slot);
+      }
+    },
+    toggleSlot(slot) {
+      fetch(`/slots/${slot.id}/toggle`, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({extra:this.extra})
+      })
+        .then(()=>this.loadSlots());
+    },
+    dayStyle(info){
+      if(!info) return {};
+      if(info.note) return {backgroundColor:'#d4edda'};
+      const max=5;
+      const intensity=Math.min(info.max,max)/max;
+      return {backgroundColor:`rgba(0,123,255,${0.2+intensity*0.6})`};
+    },
+    openDay(i){
+      this.dayView=i;
+    },
+    closeDay(){
+      this.dayView=null;
+      this.ruleMode=false;
+      this.selectedForRule=[];
+      this.ruleText='';
+    },
+    applyRule() {
+      if(!this.selectedForRule.length) return;
+      fetch('/slots/set_rule', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({slot_ids:this.selectedForRule, note:this.ruleText})
+      }).then(()=>{
+        this.ruleMode=false;
+        this.selectedForRule=[];
+        this.ruleText='';
+        this.ruleBarPos={top:0,left:0};
+        this.loadSlots();
+      });
+    },
+    cellStyle(slot) {
+      if(!slot) return {};
+      if(slot.note) return {backgroundColor:'#d4edda'};
+      const max = 5;
+      const intensity = Math.min(slot.count, max)/max;
+      return {backgroundColor:`rgba(0,123,255,${0.2+intensity*0.6})`};
+    },
+    slotTitle(slot) {
+      return slot && slot.users.length ? slot.users.join(', ') : '';
+    },
+    slotClasses(slot) {
+      return { 'rule-select': this.selectedForRule.includes(slot?.id) };
+    },
+    ruleBarStyle() {
+      return {
+        display: this.ruleMode && this.selectedForRule.length ? 'flex' : 'none',
+        top: this.ruleBarPos.top + 'px',
+        left: this.ruleBarPos.left + 'px'
+      };
+    }
+  }
+}).mount('#calendar-app');

--- a/views/calendar.erb
+++ b/views/calendar.erb
@@ -1,0 +1,63 @@
+<div id="calendar-app">
+  <p class="mb-1">Logged in as <strong><%= current_user&.name || 'Guest' %></strong></p>
+  <% unless current_user %>
+    <a href="/register" class="btn btn-sm btn-outline-primary mb-2">Register</a>
+  <% end %>
+  <div class="nav d-flex flex-wrap align-items-center gap-1">
+    <a class="btn btn-outline-primary btn-sm" :href="'/calendar?week=' + prevWeek">&laquo; Previous</a>
+    <a class="btn btn-outline-primary btn-sm" :href="'/calendar?week=' + nextWeek">Next &raquo;</a>
+    <select v-model.number="extra" class="form-select form-select-sm" style="width:auto;">
+      <option :value="0">+0</option>
+      <option v-for="n in 10" :value="n">+{{ n }}</option>
+    </select>
+    <button class="btn btn-success btn-sm" @click="ruleMode=!ruleMode" v-text="ruleMode ? 'Cancel' : 'Add Rule'"></button>
+  </div>
+  <h2 class="h5 text-center mb-2">{{ monthLabel }}</h2>
+  <div id="rule-bar" class="rule-bar input-group input-group-sm" :style="ruleBarStyle()">
+    <input type="text" class="form-control" v-model="ruleText" placeholder="Rule text">
+    <button class="btn btn-primary" @click="applyRule"><i class="bi bi-check"></i></button>
+    <span class="input-group-text" v-if="selectedForRule.length">Avg: {{ selectedAvg }}</span>
+  </div>
+  <div v-if="dayView === null">
+    <table class="table table-bordered days">
+      <tbody>
+        <tr>
+          <td v-for="(d,i) in days" class="day" @click="openDay(i)" :style="dayStyle(maxPerDay[i])" :class="{'has-rule': maxPerDay[i].note}">
+            <div class="position-relative">
+              <span class="day-label">{{ formatDay(d) }}</span>
+              <span class="count">{{ maxPerDay[i].max }}</span>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div v-else>
+    <button class="btn btn-sm btn-outline-secondary mb-2" @click="closeDay">&laquo; Back</button>
+    <table class="table table-bordered calendar">
+      <thead>
+        <tr>
+          <th>Time</th>
+          <th>{{ formatDay(days[dayView]) }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="t in times">
+          <th>{{ formatTime(t) }}</th>
+          <td class="slot" :data-slot-id="findSlotByIndex(dayView,t)?.id" :class="slotClasses(findSlotByIndex(dayView,t))" :style="cellStyle(findSlotByIndex(dayView,t))" @click="onSlotClick(findSlotByIndex(dayView,t), $event)" :data-bs-toggle="slotTitle(findSlotByIndex(dayView,t)) ? 'tooltip' : null" :title="slotTitle(findSlotByIndex(dayView,t))">
+            <span v-if="findSlotByIndex(dayView,t)" class="count">{{ findSlotByIndex(dayView,t).count }}</span>
+            <span v-if="findSlotByIndex(dayView,t) && findSlotByIndex(dayView,t).note" class="note">{{ findSlotByIndex(dayView,t).note }}</span>
+            <span v-if="findSlotByIndex(dayView,t) && findSlotByIndex(dayView,t).note" class="avg">{{ ruleAverages[findSlotByIndex(dayView,t).note] }}</span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</div>
+<script>
+var WEEK = '<%= @start_week %>';
+var PREV_WEEK = '<%= @prev_week %>';
+var NEXT_WEEK = '<%= @next_week %>';
+</script>
+<script src="/js/calendar.js"></script>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Calendar</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/cerulean/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/css/style.css"/>
+  <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body>
+  <header class="bg-primary text-white p-3 mb-4">
+    <div class="container">
+      <h1 class="h3">Telegram Calendar</h1>
+    </div>
+  </header>
+  <main class="container-fluid mb-5 px-2">
+    <%= yield %>
+  </main>
+</body>
+</html>

--- a/views/register.erb
+++ b/views/register.erb
@@ -1,0 +1,11 @@
+<h2>Register</h2>
+<form action="/register" method="post">
+  <label>Telegram ID:</label>
+  <input type="text" name="telegram_id" value="<%= @user.telegram_id %>" required>
+  <br>
+  <label>Name:</label>
+  <input type="text" name="name" value="<%= @user.name %>" required>
+  <br>
+  <input type="submit" value="Register">
+</form>
+<p>Start the Telegram bot and follow the link it sends you for automatic login.</p>


### PR DESCRIPTION
## Summary
- fix `/slots/set_rule` JSON parsing so slot notes apply
- compute rule averages client-side and show them in slot cells
- introduce a week overview that displays one cell per day
- clicking a day opens its time slots; days with notes turn green
- style day and slot cells for the new layout

## Testing
- `bundle install`
- `bundle exec rake db:migrate --trace`
- `bundle exec ruby db/seeds.rb`
- `ruby -c app.rb`


------
https://chatgpt.com/codex/tasks/task_e_6874d776e740832284a14fcd46fe9a42