### PR TITLE
Refine day view and layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/db/*.sqlite3
+/tmp

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+gem "rake"
+
+source "https://rubygems.org"
+
+# gem "rails"
+gem 'sinatra'
+gem 'sinatra-contrib'
+gem 'sinatra-activerecord'
+gem 'sqlite3'
+gem 'telegram-bot-ruby'
+gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,131 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (8.0.2)
+      activesupport (= 8.0.2)
+    activerecord (8.0.2)
+      activemodel (= 8.0.2)
+      activesupport (= 8.0.2)
+      timeout (>= 0.4.0)
+    activesupport (8.0.2)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    bigdecimal (3.2.2)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.3)
+    daemons (1.4.1)
+    drb (2.2.3)
+    dry-core (1.1.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
+    dry-inflector (1.2.0)
+    dry-logic (1.6.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-struct (1.8.0)
+      dry-core (~> 1.1)
+      dry-types (~> 1.8, >= 1.8.2)
+      ice_nine (~> 0.11)
+      zeitwerk (~> 2.6)
+    dry-types (1.8.3)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
+    eventmachine (1.2.7)
+    faraday (2.13.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.1.1)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
+    json (2.12.2)
+    logger (1.7.0)
+    minitest (5.25.5)
+    multi_json (1.16.0)
+    multipart-post (2.4.1)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    net-http (0.6.0)
+      uri
+    rack (3.1.16)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rake (13.3.0)
+    ruby2_keywords (0.0.5)
+    securerandom (0.4.1)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    sinatra-activerecord (2.0.28)
+      activerecord (>= 4.1)
+      sinatra (>= 1.0)
+    sinatra-contrib (4.1.1)
+      multi_json (>= 0.0.2)
+      mustermann (~> 3.0)
+      rack-protection (= 4.1.1)
+      sinatra (= 4.1.1)
+      tilt (~> 2.0)
+    sqlite3 (2.7.2-x86_64-linux-gnu)
+    telegram-bot-ruby (2.4.0)
+      dry-struct (~> 1.6)
+      faraday (~> 2.0)
+      faraday-multipart (~> 1.0)
+      zeitwerk (~> 2.6)
+    thin (2.0.1)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      logger
+      rack (>= 1, < 4)
+    tilt (2.6.1)
+    timeout (0.4.3)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.0.3)
+    zeitwerk (2.7.3)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  rake
+  sinatra
+  sinatra-activerecord
+  sinatra-contrib
+  sqlite3
+  telegram-bot-ruby
+  thin
+
+BUNDLED WITH
+   2.4.19

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # aitests
+
+This example uses Sinatra with SQLite to manage a simple calendar.
+
+## Setup
+
+```bash
+bundle install
+bundle exec rake db:migrate
+bundle exec ruby db/seeds.rb
+```
+
+Run the application:
+
+```bash
+bundle exec ruby app.rb
+```
+
+Telegram bot script can be executed with:
+
+```bash
+TELEGRAM_TOKEN=your_token SERVER_URL=http://localhost:4567 ruby bot.rb
+```
+
+The bot sends you a personalized link that automatically logs you in via `/auth`. Once logged in, a Vue.js powered calendar displays 30‑minute slots with a polished Bootstrap theme. Click a slot to join or leave that time. Use the number field to add extra participants (up to 10) so your name appears as `Your Name +N`. Hover over a slot to see participant names on desktop or tap the info icon to view them in a modal on mobile. Use the **Add Rule** button to select multiple slots and set a note for them, which highlights those cells in green. Cells darken as more users select the same slot and navigation links move through two‑week ranges.
+
+The `/api/slots` endpoint caches responses per week and clears the cache when slots change, reducing database load.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require 'sinatra/activerecord/rake'
+require './app'

--- a/app.rb
+++ b/app.rb
@@ -1,0 +1,132 @@
+require 'sinatra'
+require 'sinatra/activerecord'
+require 'sinatra/json'
+require 'telegram/bot'
+require 'date'
+
+set :database, {adapter: 'sqlite3', database: 'db/development.sqlite3'}
+
+enable :sessions
+
+# simple in-memory cache for slot data per week
+SLOTS_CACHE = {}
+
+class SlotUser < ActiveRecord::Base
+  self.table_name = 'slots_users'
+  belongs_to :slot
+  belongs_to :user
+end
+
+class User < ActiveRecord::Base
+  validates :telegram_id, presence: true, uniqueness: true
+  has_many :slot_users, class_name: 'SlotUser'
+  has_many :slots, through: :slot_users
+end
+
+class Slot < ActiveRecord::Base
+  validates :time, presence: true
+  has_many :slot_users, class_name: 'SlotUser'
+  has_many :users, through: :slot_users
+
+  def participant_count
+    slot_users.sum('1 + extra')
+  end
+end
+
+helpers do
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+end
+
+get '/' do
+  redirect '/calendar'
+end
+
+
+get '/auth' do
+  telegram_id = params[:telegram_id]
+  name = params[:name]
+  halt 400 unless telegram_id && name
+  user = User.find_or_create_by(telegram_id: telegram_id) do |u|
+    u.name = name
+  end
+  session[:user_id] = user.id
+  redirect '/calendar'
+end
+
+get '/register' do
+  @user = current_user || User.new(telegram_id: params[:telegram_id], name: params[:name])
+  erb :register
+end
+
+post '/register' do
+  @user = User.find_or_create_by(telegram_id: params[:telegram_id]) do |u|
+    u.name = params[:name]
+  end
+  session[:user_id] = @user.id
+  redirect '/calendar'
+end
+
+get '/calendar' do
+  date = params[:week] ? Date.parse(params[:week]) : Date.today
+  @start_week = date.beginning_of_week
+  @prev_week = @start_week - 14
+  @next_week = @start_week + 14
+  erb :calendar
+end
+
+post '/slots/:id/toggle' do
+  halt 401 unless current_user
+  payload = request.body.read
+  data = payload.empty? ? {} : JSON.parse(payload)
+  extra = data['extra'].to_i
+  slot = Slot.find(params[:id])
+  su = SlotUser.find_by(slot: slot, user: current_user)
+  if su
+    SlotUser.where(slot: slot, user: current_user).delete_all
+  else
+    SlotUser.create(slot: slot, user: current_user, extra: extra)
+  end
+  SLOTS_CACHE.clear
+  content_type :json
+  { success: true }.to_json
+end
+
+post '/slots/set_rule' do
+  halt 401 unless current_user
+  payload = request.body.read
+  data = payload.empty? ? {} : JSON.parse(payload)
+  ids = data['slot_ids']
+  note = data['note']
+  Slot.where(id: ids).update_all(note: note)
+  SLOTS_CACHE.clear
+  content_type :json
+  { success: true }.to_json
+end
+
+get '/api/slots' do
+  content_type :json
+  date = params[:week] ? Date.parse(params[:week]) : Date.today
+  start_week = date.beginning_of_week
+  key = "range_#{start_week}"
+  if SLOTS_CACHE[key]
+    return SLOTS_CACHE[key]
+  end
+  end_date = start_week + 14
+  slots = Slot.includes(slot_users: :user)
+              .where('time >= ? AND time < ?', start_week, end_date)
+              .order(:time)
+  data = slots.map do |s|
+    {
+      id: s.id,
+      time: s.time,
+      count: s.participant_count,
+      users: s.slot_users.map { |su| su.extra.positive? ? "#{su.user.name} +#{su.extra}" : su.user.name },
+      selected: current_user ? s.slot_users.any? { |su| su.user_id == current_user.id } : false,
+      note: s.note
+    }
+  end.to_json
+  SLOTS_CACHE[key] = data
+  data
+end

--- a/bot.rb
+++ b/bot.rb
@@ -1,0 +1,17 @@
+require 'telegram/bot'
+require 'net/http'
+require 'uri'
+require 'json'
+
+TOKEN = ENV['TELEGRAM_TOKEN']
+SERVER_URL = ENV['SERVER_URL'] || 'http://localhost:4567'
+
+Telegram::Bot::Client.run(TOKEN) do |bot|
+  bot.listen do |message|
+    case message.text
+    when '/start'
+      link = "#{SERVER_URL}/auth?telegram_id=#{message.from.id}&name=#{URI.encode_www_form_component(message.from.first_name)}"
+      bot.api.send_message(chat_id: message.chat.id, text: "Welcome, #{message.from.first_name}! Open this link to access the calendar: #{link}")
+    end
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/db/migrate/001_create_users.rb
+++ b/db/migrate/001_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :telegram_id, null: false
+      t.string :name
+      t.timestamps
+    end
+    add_index :users, :telegram_id, unique: true
+  end
+end

--- a/db/migrate/002_create_slots.rb
+++ b/db/migrate/002_create_slots.rb
@@ -1,0 +1,8 @@
+class CreateSlots < ActiveRecord::Migration[7.1]
+  def change
+    create_table :slots do |t|
+      t.datetime :time, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/003_create_slots_users.rb
+++ b/db/migrate/003_create_slots_users.rb
@@ -1,0 +1,8 @@
+class CreateSlotsUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :slots_users, id: false do |t|
+      t.belongs_to :slot
+      t.belongs_to :user
+    end
+  end
+end

--- a/db/migrate/004_add_note_to_slots.rb
+++ b/db/migrate/004_add_note_to_slots.rb
@@ -1,0 +1,5 @@
+class AddNoteToSlots < ActiveRecord::Migration[7.1]
+  def change
+    add_column :slots, :note, :string
+  end
+end

--- a/db/migrate/005_add_extra_to_slots_users.rb
+++ b/db/migrate/005_add_extra_to_slots_users.rb
@@ -1,0 +1,5 @@
+class AddExtraToSlotsUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :slots_users, :extra, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,36 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 5) do
+  create_table "slots", force: :cascade do |t|
+    t.datetime "time", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "note"
+  end
+
+  create_table "slots_users", id: false, force: :cascade do |t|
+    t.integer "slot_id"
+    t.integer "user_id"
+    t.integer "extra", default: 0, null: false
+    t.index ["slot_id"], name: "index_slots_users_on_slot_id"
+    t.index ["user_id"], name: "index_slots_users_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "telegram_id", null: false
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["telegram_id"], name: "index_users_on_telegram_id", unique: true
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,12 @@
+require './app'
+
+start_date = Date.today.beginning_of_week
+(0...14).each do |d|
+  day = start_date + d
+  time = day.to_time + 15 * 60 * 60
+  end_time = day.to_time + 24 * 60 * 60
+  while time <= end_time
+    Slot.find_or_create_by(time: time)
+    time += 30 * 60
+  end
+end

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,140 @@
+body {
+  background-color: #eef7fd;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+.nav {
+  margin-bottom: 1rem;
+}
+table.calendar {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+}
+table.calendar th,
+table.calendar td {
+  border: 1px solid #dee2e6;
+  text-align: center;
+  padding: 0.25rem;
+  font-size: .8rem;
+  vertical-align: middle;
+  border-radius: 4px;
+}
+table.calendar th {
+  background-color: #cfe2ff;
+}
+table.calendar td.slot {
+  cursor: pointer;
+  position: relative;
+  transition: background-color 0.3s ease;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  height: calc((100vh - 170px)/19);
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+table.calendar th.time-col,
+table.calendar td.time-col {
+  white-space: nowrap;
+  width: 120px;
+}
+table.calendar td.info-col {
+  width: 25px;
+  vertical-align: middle;
+  cursor: pointer;
+  padding: 0;
+}
+table.calendar td.slot .count {
+  font-size: 1rem;
+  font-weight: bold;
+  color: #000;
+}
+table.calendar td.slot:hover {
+  filter: brightness(0.95);
+}
+table.calendar td.slot.rule-select {
+  outline: 2px dashed #198754;
+}
+table.calendar td.slot .note {
+  font-size: 0.7rem;
+  color: #0f5132;
+  margin-left: 4px;
+}
+
+.rule-bar {
+  position: fixed;
+  display: none;
+  z-index: 1000;
+  max-width: 220px;
+  background-color: #fff;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  border-radius: 4px;
+  padding: 4px;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.days-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  grid-template-rows: auto repeat(2, auto);
+  gap: 4px;
+  width: 100%;
+}
+.days-grid .day-header {
+  background-color: #b6d4fe;
+  text-align: center;
+  font-weight: bold;
+}
+.days-grid .day {
+  cursor: pointer;
+  border: 1px solid #dee2e6;
+  background-color: #cfe2ff;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  aspect-ratio: 2 / 3;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+  border-radius: 6px;
+}
+.days-grid .day:hover {
+  transform: scale(1.03);
+}
+.days-grid .day-info {
+  font-weight: bold;
+}
+.days-grid .day-count {
+  font-size: 0.8rem;
+  margin-top: 2px;
+}
+.days-grid .day.has-rule {
+  background-color: #8fbc8f;
+}
+
+.day-view .slots-container {
+  max-height: calc(100vh - 170px);
+  overflow-y: auto;
+}
+
+@media (max-width: 576px) {
+  .days-grid {
+    grid-template-rows: auto repeat(2, auto);
+  }
+  .day-view .slots-container {
+    max-height: calc(100vh - 120px);
+  }
+  table.calendar th,
+  table.calendar td {
+    font-size: 0.75rem;
+  }
+  table.calendar td.slot {
+    height: calc((100vh - 120px)/19);
+  }
+}

--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -1,0 +1,194 @@
+const { createApp } = Vue;
+createApp({
+  data() {
+    return {
+      week: WEEK,
+      prevWeek: PREV_WEEK,
+      nextWeek: NEXT_WEEK,
+      slots: [],
+      ruleMode: false,
+      ruleText: '',
+      selectedForRule: [],
+      extra: 0,
+      dayView: null,
+      infoSlot: null
+    };
+  },
+  computed: {
+    days() {
+      const start = new Date(this.week);
+      start.setHours(0,0,0,0);
+      return Array.from({length:14}, (_,i)=>new Date(start.getTime()+i*86400000));
+    },
+    weekdayNames() {
+      const start = new Date(this.week);
+      start.setHours(0,0,0,0);
+      const opts = { weekday: 'short' };
+      return Array.from({length:7}, (_,i)=>{
+        const d = new Date(start.getTime()+i*86400000);
+        return d.toLocaleDateString(undefined, opts);
+      });
+    },
+    times() {
+      const base = this.dayView !== null ? new Date(this.days[this.dayView]) : new Date(this.week);
+      base.setHours(15,0,0,0);
+      return Array.from({length:19}, (_,i)=>new Date(base.getTime()+i*1800000));
+    },
+    monthLabel() {
+      const start = new Date(this.week);
+      const end = new Date(start.getTime()+13*86400000);
+      const opt = {month:'long', year:'numeric'};
+      return `${start.toLocaleDateString(undefined,opt)} - ${end.toLocaleDateString(undefined,opt)}`;
+    },
+    slotsByDay() {
+      const map={};
+      this.days.forEach((_,i)=>map[i]=[]);
+      this.slots.forEach(s=>{
+        const d = new Date(s.time);
+        const idx = Math.floor((d - this.getStartOfWeek()) / 86400000);
+        if(idx >= 0 && map[idx] !== undefined) map[idx].push(s);
+      });
+      return map;
+    },
+    maxPerDay() {
+      return this.days.map((_,i)=>{
+        let max=0; let note=false;
+        (this.slotsByDay[i]||[]).forEach(s=>{
+          if(s.count>max) max=s.count;
+          if(s.note) note=true;
+        });
+        return {max, note};
+      });
+    },
+    infoUsers() {
+      return this.infoSlot ? this.infoSlot.users : [];
+    }
+  },
+  mounted() {
+    this.loadSlots();
+    setInterval(this.loadSlots, 5000);
+  },
+  updated() {
+    const bar = document.getElementById('rule-bar');
+    if(bar) {
+      const style = this.ruleBarStyle();
+      Object.assign(bar.style, style);
+    }
+  },
+  methods: {
+    getStartOfWeek(){
+      const d=new Date(this.week); d.setHours(0,0,0,0); return d.getTime();
+    },
+    formatDay(d) {
+      return new Date(d).toLocaleDateString(undefined,{day:'numeric',month:'numeric'});
+    },
+    formatDayFull(d) {
+      return new Date(d).toLocaleDateString(undefined,{weekday:'long',day:'numeric',month:'numeric'});
+    },
+    formatTime(t) {
+      const start = new Date(t);
+      const end = new Date(t.getTime()+30*60*1000);
+      const opts = {hour:'2-digit', minute:'2-digit', hour12:false};
+      const startStr = start.toLocaleTimeString([],opts);
+      if(startStr === '00:00') return '00:00+';
+      return `${startStr}-${end.toLocaleTimeString([],opts)}`;
+    },
+    findSlot(day,time) {
+      const d = new Date(day);
+      d.setHours(time.getHours(), time.getMinutes(), 0, 0);
+      if(time.getDate() !== day.getDate()) {
+        d.setDate(d.getDate() + 1);
+      }
+      return this.slots.find(s => new Date(s.time).getTime() === d.getTime());
+    },
+    findSlotByIndex(dayIndex,time){
+      const day=this.days[dayIndex];
+      return this.findSlot(day,time);
+    },
+    loadSlots() {
+      fetch(`/api/slots?week=${this.week}`)
+        .then(r=>r.json())
+        .then(data=>{
+          this.slots = data;
+          if(this.infoSlot){
+            const updated = this.slots.find(s=>s.id===this.infoSlot.id);
+            if(updated) this.infoSlot = updated;
+          }
+        });
+    },
+    onSlotClick(slot, event) {
+      if(!slot) return;
+      if(this.ruleMode) {
+        const idx = this.selectedForRule.indexOf(slot.id);
+        if(idx>=0) this.selectedForRule.splice(idx,1);
+        else this.selectedForRule.push(slot.id);
+        // rule bar position fixed at bottom
+      } else {
+        this.toggleSlot(slot);
+      }
+    },
+    toggleSlot(slot) {
+      fetch(`/slots/${slot.id}/toggle`, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({extra:this.extra})
+      })
+        .then(()=>this.loadSlots());
+    },
+    dayStyle(info){
+      if(!info) return {};
+      if(info.note) return {backgroundColor:'#8fbc8f'};
+      const max=5;
+      const intensity=Math.min(info.max,max)/max;
+      return {backgroundColor:`rgba(0,123,255,${0.2+intensity*0.6})`};
+    },
+    openDay(i){
+      this.dayView=i;
+    },
+    closeDay(){
+      this.dayView=null;
+      this.ruleMode=false;
+      this.selectedForRule=[];
+      this.ruleText='';
+    },
+    applyRule() {
+      if(!this.selectedForRule.length) return;
+      fetch('/slots/set_rule', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({slot_ids:this.selectedForRule, note:this.ruleText})
+      }).then(()=>{
+        this.ruleMode=false;
+        this.selectedForRule=[];
+        this.ruleText='';
+        this.loadSlots();
+      });
+    },
+    cellStyle(slot) {
+      if(!slot) return {};
+      if(slot.note) return {backgroundColor:'#8fbc8f'};
+      const max = 5;
+      const intensity = Math.min(slot.count, max)/max;
+      return {backgroundColor:`rgba(0,123,255,${0.2+intensity*0.6})`};
+    },
+    slotTitle(slot) {
+      return slot && slot.users.length ? slot.users.join(', ') : '';
+    },
+    slotClasses(slot) {
+      return {
+        'rule-select': this.selectedForRule.includes(slot?.id),
+        'has-note': !!slot?.note
+      };
+    },
+    ruleBarStyle() {
+      return {
+        display: this.ruleMode && this.selectedForRule.length ? 'flex' : 'none'
+      };
+    },
+    showInfo(slot){
+      this.infoSlot = slot;
+      const modal = new bootstrap.Modal(document.getElementById('infoModal'));
+      modal.show();
+    }
+  }
+}).mount('#calendar-app');

--- a/views/calendar.erb
+++ b/views/calendar.erb
@@ -1,0 +1,82 @@
+<div id="calendar-app">
+  <p class="mb-1">Logged in as <strong><%= current_user&.name || 'Guest' %></strong></p>
+  <% unless current_user %>
+    <a href="/register" class="btn btn-sm btn-outline-primary mb-2">Register</a>
+  <% end %>
+  <div class="nav d-flex flex-wrap align-items-center gap-1" v-if="dayView === null">
+    <a class="btn btn-outline-primary btn-sm" :href="'/calendar?week=' + prevWeek">&laquo; Previous 2 weeks</a>
+    <a class="btn btn-outline-primary btn-sm" :href="'/calendar?week=' + nextWeek">Next 2 weeks &raquo;</a>
+  </div>
+  <div class="nav d-flex flex-wrap align-items-center gap-1" v-if="dayView !== null">
+    <select v-model.number="extra" class="form-select form-select-sm" style="width:auto;">
+      <option :value="0">+0</option>
+      <option v-for="n in 10" :value="n">+{{ n }}</option>
+    </select>
+    <button class="btn btn-success btn-sm" @click="ruleMode=!ruleMode" v-text="ruleMode ? 'Cancel' : 'Add Rule'"></button>
+  </div>
+  <div id="rule-bar" class="rule-bar input-group input-group-sm" :style="ruleBarStyle()">
+    <input type="text" class="form-control" v-model="ruleText" placeholder="Rule text">
+    <button class="btn btn-primary" @click="applyRule"><i class="bi bi-check"></i></button>
+  </div>
+  <div v-if="dayView === null">
+    <div class="days-grid">
+      <div v-for="d in weekdayNames" class="day-header">{{ d }}</div>
+      <template v-for="(day, idx) in days">
+        <div class="day" @click="openDay(idx)" :style="dayStyle(maxPerDay[idx])" :class="{'has-rule': maxPerDay[idx].note}">
+          <div class="day-info">{{ formatDay(day) }}</div>
+          <div class="day-count">{{ maxPerDay[idx].max }}</div>
+        </div>
+      </template>
+    </div>
+  </div>
+  <div v-else class="day-view">
+    <button class="btn btn-sm btn-outline-secondary mb-2" @click="closeDay">&laquo; Back</button>
+    <div class="slots-container">
+    <table class="table table-bordered calendar">
+      <thead>
+        <tr>
+          <th class="time-col">Time</th>
+          <th>{{ formatDayFull(days[dayView]) }}</th>
+          <th class="info-col"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="t in times">
+          <th class="time-col">{{ formatTime(t) }}</th>
+          <td class="slot" :data-slot-id="findSlotByIndex(dayView,t)?.id" :class="slotClasses(findSlotByIndex(dayView,t))" :style="cellStyle(findSlotByIndex(dayView,t))" @click="onSlotClick(findSlotByIndex(dayView,t), $event)">
+            <div class="count" v-if="findSlotByIndex(dayView,t)">{{ findSlotByIndex(dayView,t).count }}</div>
+            <div class="note" v-if="findSlotByIndex(dayView,t) && findSlotByIndex(dayView,t).note">
+              {{ findSlotByIndex(dayView,t).note }}
+            </div>
+          </td>
+          <td class="info-col" @click="showInfo(findSlotByIndex(dayView,t))" v-if="findSlotByIndex(dayView,t)">
+            👶🖐
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    </div>
+  </div>
+
+  <div class="modal fade" id="infoModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Participants</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <ul class="list-unstyled mb-0">
+            <li v-for="u in infoUsers" :key="u">{{ u }}</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+var WEEK = '<%= @start_week %>';
+var PREV_WEEK = '<%= @prev_week %>';
+var NEXT_WEEK = '<%= @next_week %>';
+</script>
+<script src="/js/calendar.js"></script>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Calendar</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/cerulean/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/css/style.css"/>
+  <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body>
+  <header class="bg-primary text-white p-3 mb-4">
+    <div class="container">
+      <h1 class="h3">Telegram Calendar</h1>
+    </div>
+  </header>
+  <main class="container-fluid mb-5 px-2">
+    <%= yield %>
+  </main>
+  <footer class="bg-light text-center text-muted py-2 mt-auto">
+    made by me, 2025
+  </footer>
+</body>
+</html>

--- a/views/register.erb
+++ b/views/register.erb
@@ -1,0 +1,11 @@
+<h2>Register</h2>
+<form action="/register" method="post">
+  <label>Telegram ID:</label>
+  <input type="text" name="telegram_id" value="<%= @user.telegram_id %>" required>
+  <br>
+  <label>Name:</label>
+  <input type="text" name="name" value="<%= @user.name %>" required>
+  <br>
+  <input type="submit" value="Register">
+</form>
+<p>Start the Telegram bot and follow the link it sends you for automatic login.</p>


### PR DESCRIPTION
## Summary
- keep body scrollable and show footer
- shorten day blocks with an aspect ratio
- place rule bar at bottom center
- compute times per selected day and map slots by day correctly
- show participants button with emoji

## Testing
- `bundle install`
- `bundle exec rake db:migrate --trace`
- `bundle exec ruby db/seeds.rb`
- `ruby -c app.rb`
- `ruby -c bot.rb`


------
https://chatgpt.com/codex/tasks/task_e_6874d776e740832284a14fcd46fe9a42